### PR TITLE
Fix typo and add test coverage

### DIFF
--- a/src/ThinqChannel.php
+++ b/src/ThinqChannel.php
@@ -4,7 +4,6 @@ namespace R64\LaravelThinq;
 
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Support\Facades\Log;
 
 class ThinqChannel
 {
@@ -19,11 +18,6 @@ class ThinqChannel
 
     public function send($notifiable, Notification $notification)
     {
-        // Since thinq is restricted to IP, disable or enable api call when testing
-        if ($this->shouldDisableApiCall()) {
-            return;
-        }
-
         $message = $notification->toThinq($notifiable);
 
         if(property_exists($notification, 'silent') && $notification->silent) {
@@ -31,10 +25,5 @@ class ThinqChannel
         } else {
             $this->thinq->withMessage($message)->sentSms();
         }
-    }
-
-    private function shoudDisableApiCall()
-    {
-        return app()->environment('local') && config('thinq.disable_api_calls');
     }
 }

--- a/src/ThinqConfig.php
+++ b/src/ThinqConfig.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace R64\LaravelThinq;
+
+class ThinqConfig
+{
+    public function getApiKey()
+    {
+        return config('thinq.api_key');
+    }
+
+    public function getAccountId()
+    {
+        return config('thinq.account_id');
+    }
+
+    public function shouldDisableApiCalls()
+    {
+        return config('thinq.disable_api_calls');
+    }
+}

--- a/tests/ThinqChannelTest.php
+++ b/tests/ThinqChannelTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace R64\LaravelThinq\Tests;
+
+use Mockery;
+use R64\LaravelThinq\Thinq;
+use R64\LaravelThinq\ThinqChannel;
+use R64\LaravelThinq\ThinqMessage;
+use Illuminate\Support\Facades\App;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Events\Dispatcher;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class ThinqChannelTest extends MockeryTestCase
+{
+    public $thinq;
+    public $channel;
+
+    public $dispatcher;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->thinq = Mockery::mock(Thinq::class);
+        $this->dispatcher = Mockery::mock(Dispatcher::class);
+
+        $this->channel = new ThinqChannel($this->thinq, $this->dispatcher);
+    }
+
+    /**
+     * @test
+     */
+    public function can_send_thinq_message()
+    {
+        $notifiable = new Class {};
+        $notification = Mockery::mock(Notification::class);
+        
+        $message = new ThinqMessage('Message', '+1234567890', '+2346788778');
+        $notification->shouldReceive('toThinq')->andReturn($message);
+        
+        $this->thinq->shouldReceive('withMessage')
+            ->with($message)
+            ->andReturn($this->thinq);
+
+        $this->thinq->shouldReceive('sentSms')
+            ->once();
+
+        App::shouldReceive('environment')
+            ->andReturn('production');
+
+        $this->channel->send($notifiable, $notification);
+    }
+}

--- a/tests/ThinqMessageTest.php
+++ b/tests/ThinqMessageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace R64\LaravelThinq\Tests;
+
+use PHPUnit\Framework\TestCase;
+use R64\LaravelThinq\ThinqMessage;
+
+class ThinqMessageTest extends TestCase
+{
+    public $thinqMessage;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->thinqMessage = new ThinqMessage('Hello, this is thinq message', '+2334988499', '+1234567890');
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_thinq_message()
+    {
+        $expected = $this->thinqMessage->getMessage();
+
+        $this->assertEquals('Hello, this is thinq message', $expected['message']);
+        $this->assertEquals('+2334988499', $expected['from_did']);
+        $this->assertEquals('+1234567890', $expected['to_did']);
+    }
+}

--- a/tests/ThinqTest.php
+++ b/tests/ThinqTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace R64\LaravelThinq\Tests;
+
+use Mockery;
+use R64\LaravelThinq\Thinq;
+use R64\LaravelThinq\ThinqConfig;
+use R64\LaravelThinq\ThinqMessage;
+use Illuminate\Support\Facades\App;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class ThinqTest extends MockeryTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->config = Mockery::mock(ThinqConfig::class);
+        $this->thinqMessage = Mockery::mock(ThinqMessage::class);
+
+        $this->thinq = new Thinq($this->config);
+    }
+
+    /**
+     * @test
+     */
+    public function can_send_a_message_to_thinq()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unauthorized');
+
+        $this->config->shouldReceive([
+            'getApiKey' => '12345xxxx',
+            'getAccountId' => 'sdxxx12345',
+        ]);
+
+        $this->thinqMessage->shouldReceive('getMessage')
+            ->andReturn([
+                'from_did' => '+1234567890',
+                'to_did' => '+2346788778',
+                'message' => 'Message text',
+            ]);
+
+        $this->thinq->thinqMessage = $this->thinqMessage;
+
+        App::shouldReceive('environment')
+            ->andReturn('production');
+
+        $this->thinq->sentSms();
+    }
+
+    /**
+     * @test
+     */
+    public function can_send_silent_sms_message_to_thinq()
+    {
+        $this->config->shouldReceive([
+            'getApiKey' => '12345xxxx',
+            'getAccountId' => 'sdxxx12345',
+        ]);
+
+        $this->thinqMessage->shouldReceive('getMessage')
+            ->andReturn([
+                'from_did' => '+1234567890',
+                'to_did' => '+2346788778',
+                'message' => 'Message text',
+            ]);
+
+        $this->thinq->thinqMessage = $this->thinqMessage;
+
+        App::shouldReceive('environment')
+            ->andReturn('production');
+
+        $this->thinq->sentSilentSms();
+    }
+
+    /**
+     * @test
+     * 
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function will_not_make_api_call_when_disabled()
+    {
+        $this->config->shouldReceive([
+            'getApiKey' => '12345xxxx',
+            'getAccountId' => 'sdxxx12345',
+            'shouldDisableApiCalls' => true,
+        ]);
+
+        $this->config->shouldReceive('shouldDisableApiCalls')
+            ->andReturn(true);
+
+        $this->thinqMessage->shouldReceive('getMessage')
+            ->andReturn([
+                'from_did' => '+1234567890',
+                'to_did' => '+2346788778',
+                'message' => 'Message text',
+            ]);
+
+        $this->thinq->thinqMessage = $this->thinqMessage;
+
+        App::shouldReceive('environment')
+            ->andReturn('local');
+
+        $expected = $this->thinq->sentSms();
+        $this->assertNull($expected);
+    }
+}


### PR DESCRIPTION
There was a typo when I was calling `shouldDisableApiCall`. This pr fixes the typo and also adds test coverage to prevent future occurrence.

![larave-thinq-test-passing](https://user-images.githubusercontent.com/8011922/54290139-571c4600-45a2-11e9-99e0-22e0fded2a7d.png)
